### PR TITLE
Improve handling of multiple and nested errors

### DIFF
--- a/src/Containers/ParsedInput.php
+++ b/src/Containers/ParsedInput.php
@@ -106,6 +106,16 @@ class ParsedInput extends RawInput implements \ArrayAccess {
 
         $unexpected = array_merge($unexpected, array_keys($data));
 
+        // This is a not-beautiful way of expressing "if at least two error
+        // arrays are nonempty", since this should retain the more specific
+        // exception code when only one type of error is present.
+        if (($missing && ($invalid || $unexpected)) || ($invalid && $unexpected)) {
+            throw new InputException(
+                InputException::MULTIPLE_VALUE_ERRORS,
+                compact('invalid', 'missing', 'unexpected')
+            );
+        }
+
         if ($missing) {
             throw new InputException(InputException::MISSING_VALUES, $missing);
         }

--- a/src/Containers/ParsedInput.php
+++ b/src/Containers/ParsedInput.php
@@ -58,7 +58,6 @@ class ParsedInput extends RawInput implements \ArrayAccess {
             try {
                 $clean_out[$key] = $input->setValue($data[$key])
                     ->evaluate();
-                unset($data[$key]);
             } catch (InputException $e) {
                 $invalid = array_merge($invalid, array_map(function ($k) use ($key) {
                     return $key . '.' . $k;
@@ -69,9 +68,10 @@ class ParsedInput extends RawInput implements \ArrayAccess {
                 $unexpected = array_merge($unexpected, array_map(function ($k) use ($key) {
                     return $key . '.' . $k;
                 }, $e->getUnexpected()));
-                unset($data[$key]);
             } catch (UnexpectedValueException $e) {
                 $invalid[] = $key;
+            } finally {
+                unset($data[$key]);
             }
         } unset($key, $input);
 
@@ -80,7 +80,6 @@ class ParsedInput extends RawInput implements \ArrayAccess {
                 try {
                     $clean_out[$key] = $input->setValue($data[$key])
                         ->evaluate();
-                    unset($data[$key]);
                 } catch (InputException $e) {
                     $invalid = array_merge($invalid, array_map(function ($k) use ($key) {
                         return $key . '.' . $k;
@@ -91,9 +90,10 @@ class ParsedInput extends RawInput implements \ArrayAccess {
                     $unexpected = array_merge($unexpected, array_map(function ($k) use ($key) {
                         return $key . '.' . $k;
                     }, $e->getUnexpected()));
-                    unset($data[$key]);
                 } catch (UnexpectedValueException $e) {
                     $invalid[] = $key;
+                } finally {
+                    unset($data[$key]);
                 }
             } else {
                 // Somehow, there should be a concept of "use default

--- a/src/Containers/ParsedInput.php
+++ b/src/Containers/ParsedInput.php
@@ -59,15 +59,12 @@ class ParsedInput extends RawInput implements \ArrayAccess {
                 $clean_out[$key] = $input->setValue($data[$key])
                     ->evaluate();
             } catch (InputException $e) {
-                $invalid = array_merge($invalid, array_map(function ($k) use ($key) {
+                $prefix = function ($k) use ($key) {
                     return $key . '.' . $k;
-                }, $e->getInvalid()));
-                $missing = array_merge($missing, array_map(function ($k) use ($key) {
-                    return $key . '.' . $k;
-                }, $e->getMissing()));
-                $unexpected = array_merge($unexpected, array_map(function ($k) use ($key) {
-                    return $key . '.' . $k;
-                }, $e->getUnexpected()));
+                };
+                $invalid = array_merge($invalid, array_map($prefix, $e->getInvalid()));
+                $missing = array_merge($missing, array_map($prefix, $e->getMissing()));
+                $unexpected = array_merge($unexpected, array_map($prefix, $e->getUnexpected()));
             } catch (UnexpectedValueException $e) {
                 $invalid[] = $key;
             } finally {
@@ -81,15 +78,12 @@ class ParsedInput extends RawInput implements \ArrayAccess {
                     $clean_out[$key] = $input->setValue($data[$key])
                         ->evaluate();
                 } catch (InputException $e) {
-                    $invalid = array_merge($invalid, array_map(function ($k) use ($key) {
+                    $prefix = function ($k) use ($key) {
                         return $key . '.' . $k;
-                    }, $e->getInvalid()));
-                    $missing = array_merge($missing, array_map(function ($k) use ($key) {
-                        return $key . '.' . $k;
-                    }, $e->getMissing()));
-                    $unexpected = array_merge($unexpected, array_map(function ($k) use ($key) {
-                        return $key . '.' . $k;
-                    }, $e->getUnexpected()));
+                    };
+                    $invalid = array_merge($invalid, array_map($prefix, $e->getInvalid()));
+                    $missing = array_merge($missing, array_map($prefix, $e->getMissing()));
+                    $unexpected = array_merge($unexpected, array_map($prefix, $e->getUnexpected()));
                 } catch (UnexpectedValueException $e) {
                     $invalid[] = $key;
                 } finally {

--- a/tests/Containers/ParsedInputTest.php
+++ b/tests/Containers/ParsedInputTest.php
@@ -256,6 +256,17 @@ class ParsedInputTest extends \PHPUnit\Framework\TestCase {
                 ['struct.b'],
                 true,
             ],
+            [
+                new InputException(InputException::MULTIPLE_VALUE_ERRORS, [
+                    'invalid' => ['a'],
+                    'missing' => ['c'],
+                    'unexpected' => ['b'],
+                ]),
+                ['struct.a'],
+                ['struct.c'],
+                ['struct.b'],
+                true,
+            ],
             // Optional inputs
             [
                 new InputException(InputException::INVALID_VALUES, ['a']),
@@ -282,6 +293,17 @@ class ParsedInputTest extends \PHPUnit\Framework\TestCase {
                 new InputException(InputException::UNEXPECTED_VALUES, ['b']),
                 [],
                 [],
+                ['struct.b'],
+                false,
+            ],
+            [
+                new InputException(InputException::MULTIPLE_VALUE_ERRORS, [
+                    'invalid' => ['a'],
+                    'missing' => ['c'],
+                    'unexpected' => ['b'],
+                ]),
+                ['struct.a'],
+                ['struct.c'],
                 ['struct.b'],
                 false,
             ],


### PR DESCRIPTION
InputObjects being validated may now choose to throw an InputException during the validate/evaluate process, better allowing for user-defined structures to indicate their validation errors. The convention is such that any InputExceptions caught during the outer validation will prefix that InputObject's corresponding input key on to the outermost error.