### PR TITLE
Improve phpunit8 compatibility

### DIFF
--- a/tests/Containers/ParsedInputTest.php
+++ b/tests/Containers/ParsedInputTest.php
@@ -2,8 +2,11 @@
 
 namespace Firehed\Input\Containers;
 
+use BadMethodCallException;
+use DomainException;
 use Firehed\Input\Exceptions\InputException;
 use Firehed\Input\Objects\InputObject;
+use UnexpectedValueException;
 
 /**
  * @coversDefaultClass Firehed\Input\Containers\ParsedInput
@@ -36,10 +39,10 @@ class ParsedInputTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @covers ::offsetGet
-     * @expectedException DomainException
      */
     public function testBadOffset() {
         $obj = new ParsedInput([]);
+        $this->expectException(DomainException::class);
         $data = $obj['foo'];
     } // testBadOffset
 
@@ -55,48 +58,48 @@ class ParsedInputTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @covers ::offsetExists
-     * @expectedException BadMethodCallException
      */
     public function testIssetThrows() {
         $obj = new ParsedInput([]);
+        $this->expectException(BadMethodCallException::class);
         isset($obj['foo']);
     } // testIssetThrows
 
     /**
      * @covers ::offsetExists
-     * @expectedException BadMethodCallException
      */
     public function testEmptyThrows() {
         $obj = new ParsedInput([]);
+        $this->expectException(BadMethodCallException::class);
         empty($obj['foo']);
     } // testEmptyThrows
 
     /**
      * @covers ::offsetUnset
-     * @expectedException BadMethodCallException
      */
     public function testUnsetThrows() {
         $obj = new ParsedInput([]);
+        $this->expectException(BadMethodCallException::class);
         unset($obj['foo']);
     } // testUnsetThrows
 
     /**
      * @covers ::offsetSet
-     * @expectedException BadMethodCallException
      */
     public function testSetThrows() {
         $obj = new ParsedInput([]);
+        $this->expectException(BadMethodCallException::class);
         $obj['foo'] = 'bar';
     } // testSetThrows
 
     // ----(Validation:Unexpected Parameters)----------------------------------
     /**
      * @covers ::validate
-     * @expectedException Firehed\Input\Exceptions\InputException
-     * @expectedExceptionCode Firehed\Input\Exceptions\InputException::UNEXPECTED_VALUES
      */
     public function testUnexpectedParametersAreCaught() {
         $parsed = new ParsedInput(['foo' => 'bar']);
+        $this->expectException(InputException::class);
+        $this->expectExceptionCode(InputException::UNEXPECTED_VALUES);
         $parsed->validate($this->getValidation());
     } // testUnexpectedParametersAreCaught
 
@@ -118,26 +121,26 @@ class ParsedInputTest extends \PHPUnit\Framework\TestCase {
 
    /**
      * @covers ::validate
-     * @expectedException Firehed\Input\Exceptions\InputException
-     * @expectedExceptionCode Firehed\Input\Exceptions\InputException::INVALID_VALUES
      */
     public function testInvalidRequiredParametersAreCaught() {
         $this->addRequired('short', $this->getMockIO(false));
 
         $parsed = new ParsedInput(['short' => 123]);
+        $this->expectException(InputException::class);
+        $this->expectExceptionCode(InputException::INVALID_VALUES);
         $parsed->validate($this->getValidation());
     } // testInvalidRequiredParametersAreCaught
 
     /**
      * @covers ::validate
-     * @expectedException Firehed\Input\Exceptions\InputException
-     * @expectedExceptionCode Firehed\Input\Exceptions\InputException::MISSING_VALUES
      */
     public function testMissingRequiredParametersAreCaught() {
         $this->addRequired('short',
             $this->getMockForAbstractClass('Firehed\Input\Objects\InputObject'));
 
         $parsed = new ParsedInput([]);
+        $this->expectException(InputException::class);
+        $this->expectExceptionCode(InputException::MISSING_VALUES);
         $parsed->validate($this->getValidation());
     } // testMissingRequiredParametersAreCaught
 
@@ -176,12 +179,12 @@ class ParsedInputTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @covers ::validate
-     * @expectedException Firehed\Input\Exceptions\InputException
-     * @expectedExceptionCode Firehed\Input\Exceptions\InputException::INVALID_VALUES
      */
     public function testInvalidOptionalParametersAreCaught() {
         $this->addOptional('short', $this->getMockIO(false));
         $parsed = new ParsedInput(['short' => 123]);
+        $this->expectException(InputException::class);
+        $this->expectExceptionCode(InputException::INVALID_VALUES);
         $parsed->validate($this->getValidation());
     } // testInvalidOptionalParametersAreCaught
 
@@ -409,7 +412,7 @@ class ParsedInputTest extends \PHPUnit\Framework\TestCase {
         else {
             $mock->expects($this->atLeastOnce())
                 ->method('evaluate')
-                ->will($this->throwException(new \UnexpectedValueException));
+                ->will($this->throwException(new UnexpectedValueException));
         }
         return $mock;
     } // getMockIO

--- a/tests/Containers/SafeInputTest.php
+++ b/tests/Containers/SafeInputTest.php
@@ -2,6 +2,8 @@
 
 namespace Firehed\Input\Containers;
 
+use BadMethodCallException;
+
 /**
  * @coversDefaultClass Firehed\Input\Containers\SafeInput
  */
@@ -30,7 +32,6 @@ class SafeInputTest extends \PHPUnit\Framework\TestCase {
 
     /**
      * @covers ::__construct
-     * @expectedException BadMethodCallException
      */
     public function testConstructThrowsWithUnvalidatedInput() {
         $valid = $this->getMockBuilder('Firehed\Input\Containers\ParsedInput')
@@ -39,6 +40,7 @@ class SafeInputTest extends \PHPUnit\Framework\TestCase {
         $valid->expects($this->atLeastOnce())
             ->method('isValidated')
             ->will($this->returnValue(false));
+        $this->expectException(BadMethodCallException::class);
         new SafeInput($valid);
     } // testConstructThrowsWithUnvalidatedInput
 

--- a/tests/Parsers/JSONTest.php
+++ b/tests/Parsers/JSONTest.php
@@ -2,6 +2,8 @@
 
 namespace Firehed\Input\Parsers;
 
+use Firehed\Input\Exceptions\InputException;
+
 /**
  * @coversDefaultClass Firehed\Input\Parsers\JSON
  */
@@ -50,22 +52,22 @@ class JSONTest extends \PHPUnit\Framework\TestCase {
     /**
      * @covers ::parse
      * @dataProvider invalidJSON
-     * @expectedException Firehed\Input\Exceptions\InputException
-     * @expectedExceptionCode Firehed\Input\Exceptions\InputException::PARSE_ERROR
      */
     public function testParseError($json) {
         $parser = new JSON;
+        $this->expectException(InputException::class);
+        $this->expectExceptionCode(InputException::PARSE_ERROR);
         $parser->parse($json);
     } // testParseError
 
     /**
      * @covers ::parse
      * @dataProvider formatErrors
-     * @expectedException Firehed\Input\Exceptions\InputException
-     * @expectedExceptionCode Firehed\Input\Exceptions\InputException::FORMAT_ERROR
      */
     public function testFormatError($json) {
         $parser = new JSON;
+        $this->expectException(InputException::class);
+        $this->expectExceptionCode(InputException::FORMAT_ERROR);
         $parser->parse($json);
     } // testFormatError
 }

--- a/tests/Parsers/URLEncodedTest.php
+++ b/tests/Parsers/URLEncodedTest.php
@@ -2,6 +2,8 @@
 
 namespace Firehed\Input\Parsers;
 
+use Firehed\Input\Exceptions\InputException;
+
 /**
  * @coversDefaultClass Firehed\Input\Parsers\URLEncoded
  */
@@ -38,11 +40,11 @@ class URLEncodedTest extends \PHPUnit\Framework\TestCase {
     /**
      * @covers ::parse
      * @dataProvider formatErrors
-     * @expectedException Firehed\Input\Exceptions\InputException
-     * @expectedExceptionCode Firehed\Input\Exceptions\InputException::FORMAT_ERROR
      */
     public function testFormatError($data) {
         $parser = new URLEncoded;
+        $this->expectException(InputException::class);
+        $this->expectExceptionCode(InputException::FORMAT_ERROR);
         $parser->parse($data);
     } // testFormatError
 }


### PR DESCRIPTION
This doesn't yet add `:void`, but that will be done in a the next major which will drop 7.0 support.